### PR TITLE
Fix disableLauncher and listener callback issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@ kotlin.native.enableDependencyPropagation=false
 kotlin.js.compiler=ir
 
 # SDK Version (single source of truth - read by build.gradle.kts for Maven publishing)
-VERSION_NAME=1.0.7
+VERSION_NAME=1.0.8
 


### PR DESCRIPTION
## Summary
- Fix `disableLauncher=true` causing blank page by deferring `open()` to `onChatReady()` callback
- Fix `onChatClosed` not firing when tapping X button by adding MutationObserver fallback
- Add state deduplication in MessageBridge to prevent duplicate callbacks
- Clean up logging to be conditional on debug mode

## Test plan
- [ ] Test with `disableLauncher=true` - chat should open automatically without blank page
- [ ] Test tapping X button in chat - `onChatClosed()` should fire
- [ ] Test with `debug=false` - no logs should appear in logcat
- [ ] Test with `debug=true` - debug logs should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)