### PR TITLE
Send country metadata when no UserData is configured

### DIFF
--- a/assembledchat/src/main/kotlin/com/assembled/chat/AssembledChat.kt
+++ b/assembledchat/src/main/kotlin/com/assembled/chat/AssembledChat.kt
@@ -324,7 +324,10 @@ class AssembledChat(private val configuration: AssembledChatConfiguration) {
 
     private fun buildChatHtml(): String {
         val country = countryFallback!!
-        val userDataJs = configuration.userData?.withCountryFallback(country)?.toJavaScript() ?: "null"
+        val userDataJs = configuration.userData
+            ?.withCountryFallback(country)
+            ?.toJavaScript()
+            ?: UserData.countryOnlyJavaScript(country)
         val jwtTokenJs = configuration.jwtToken?.let { "'${it.replace("'", "\\'")}'" } ?: "null"
         val profileIdAttr = configuration.profileId?.let { "data-profile-id=\"$it\"" } ?: ""
         val disableLauncherAttr = if (configuration.disableLauncher) "data-disable-launcher=\"true\"" else ""
@@ -375,6 +378,7 @@ class AssembledChat(private val configuration: AssembledChatConfiguration) {
 
                                 var userData = $userDataJs;
                                 if (userData) {
+                                    log('Calling setUserData with: ' + JSON.stringify(userData));
                                     window.assembled.setUserData(userData);
                                 }
 

--- a/assembledchat/src/main/kotlin/com/assembled/chat/models/UserData.kt
+++ b/assembledchat/src/main/kotlin/com/assembled/chat/models/UserData.kt
@@ -49,4 +49,16 @@ data class UserData(
     }
 
     private fun String.escapeForJs(): String = this.replace("'", "\\'")
+
+    internal companion object {
+        /**
+         * Builds a metadata-only JS payload for callers that haven't supplied a
+         * [UserData], so the web widget still receives the device-region country
+         * even without explicit user data or a JWT.
+         */
+        internal fun countryOnlyJavaScript(country: String): String {
+            val escaped = country.replace("'", "\\'")
+            return "{ metadata: { 'country': '$escaped' } }"
+        }
+    }
 }

--- a/assembledchat/src/test/kotlin/com/assembled/chat/models/UserDataTest.kt
+++ b/assembledchat/src/test/kotlin/com/assembled/chat/models/UserDataTest.kt
@@ -120,6 +120,23 @@ class UserDataTest {
     }
 
     @Test
+    fun `countryOnlyJavaScript emits metadata-only payload`() {
+        val js = UserData.countryOnlyJavaScript("US")
+
+        assertContains(js, "metadata: {")
+        assertContains(js, "'country': 'US'")
+        assertFalse(js.contains("userId"))
+        assertFalse(js.contains("email"))
+    }
+
+    @Test
+    fun `countryOnlyJavaScript escapes single quotes in country`() {
+        val js = UserData.countryOnlyJavaScript("U'S")
+
+        assertContains(js, "'country': 'U\\'S'")
+    }
+
+    @Test
     fun `withCountryFallback preserves blank metadata country`() {
         val userData = UserData(
             userId = "user-123",

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@ kotlin.native.enableDependencyPropagation=false
 kotlin.js.compiler=ir
 
 # SDK Version (single source of truth - read by build.gradle.kts for Maven publishing)
-VERSION_NAME=1.0.8
+VERSION_NAME=1.0.9
 


### PR DESCRIPTION
## Summary
- Country fallback previously only applied when the host passed a `UserData` object — JWT-only and unauthenticated flows skipped `setUserData` entirely, so `metadata.country` never reached the widget.
- Emit a metadata-only payload via `UserData.countryOnlyJavaScript` when `configuration.userData` is null, so the device-region country is always sent on init.
- Bumps `VERSION_NAME` to 1.0.9.

## Test plan
- [x] `./gradlew :assembledchat:testDebugUnitTest` — passing
- [x] Local validation against `AssembledTestApp` (JWT-only, no UserData) via `mavenLocal` — observed `setUserData with: {"metadata":{"country":"US"}}` in WebView console
- [ ] Confirm Maven Central publish succeeds when tag `v1.0.9` is pushed
